### PR TITLE
settings: Permitir utilizar un token distinto configurando el entorno

### DIFF
--- a/secomplican/secomplican/settings.py
+++ b/secomplican/secomplican/settings.py
@@ -22,7 +22,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/dev/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'iynt*x$0lw1v7c$g8#^li#2(k6g@l*p83)7hylb14t**em@s6v'
+SECRET_KEY = os.environ.get(
+    'secomplican_KEY',
+    'iynt*x$0lw1v7c$g8#^li#2(k6g@l*p83)7hylb14t**em@s6v'
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Cómo marcaron en [esta tarjeta](https://trello.com/c/D50kSCBF/) es una buena idea que una parte de los settings sea fácilmente configurable.

Este es un acercamiento híper simplista (otra forma es definir distintos settings.py que pisen hagan un `from secomplican.settings import *` y luego pisen las variables adecuadas, esto es lo que estoy haciendo para levantar mi entorno con sqlite). A la hora de correr con un módulo de configuración distinto se puede usar la variable de entorno `DJANGO_SETTINGS_MODULE` y/o pasarle el flag `--settings=<modulo>` al `manage.py`.

Dicho esto, se les ahorré media línea de código síentanse libres de mergear :D